### PR TITLE
test(e2e): regenerate golden fixtures for km/h wind units

### DIFF
--- a/tests/e2e/fixtures/api_v1_observations_daily__end=2021-02-20000000_start=2021-02-10000000_station_id=simulator.json
+++ b/tests/e2e/fixtures/api_v1_observations_daily__end=2021-02-20000000_start=2021-02-10000000_station_id=simulator.json
@@ -18,8 +18,8 @@
     "temp_outdoor_max": 0.2,
     "temp_outdoor_min": -18.2,
     "uv_index_max": null,
-    "wind_gust_max": 5.3,
-    "wind_speed_avg": 2.7966666666666673,
+    "wind_gust_max": 19.1,
+    "wind_speed_avg": 10.070833333333335,
     "wind_speed_max": null
   },
   {
@@ -41,8 +41,8 @@
     "temp_outdoor_max": -7.4,
     "temp_outdoor_min": -16.1,
     "uv_index_max": null,
-    "wind_gust_max": 8.5,
-    "wind_speed_avg": 3.689166666666667,
+    "wind_gust_max": 30.6,
+    "wind_speed_avg": 13.283333333333333,
     "wind_speed_max": null
   },
   {
@@ -64,8 +64,8 @@
     "temp_outdoor_max": -6.8,
     "temp_outdoor_min": -12.0,
     "uv_index_max": null,
-    "wind_gust_max": 7.0,
-    "wind_speed_avg": 2.8370833333333336,
+    "wind_gust_max": 25.2,
+    "wind_speed_avg": 10.216666666666669,
     "wind_speed_max": null
   },
   {
@@ -87,8 +87,8 @@
     "temp_outdoor_max": -10.6,
     "temp_outdoor_min": -25.8,
     "uv_index_max": null,
-    "wind_gust_max": 6.4,
-    "wind_speed_avg": 2.5429166666666667,
+    "wind_gust_max": 23.0,
+    "wind_speed_avg": 9.162500000000003,
     "wind_speed_max": null
   },
   {
@@ -110,8 +110,8 @@
     "temp_outdoor_max": -17.1,
     "temp_outdoor_min": -23.0,
     "uv_index_max": null,
-    "wind_gust_max": 13.1,
-    "wind_speed_avg": 5.617916666666666,
+    "wind_gust_max": 47.2,
+    "wind_speed_avg": 20.229166666666668,
     "wind_speed_max": null
   },
   {
@@ -133,8 +133,8 @@
     "temp_outdoor_max": -10.8,
     "temp_outdoor_min": -16.8,
     "uv_index_max": null,
-    "wind_gust_max": 13.2,
-    "wind_speed_avg": 6.920833333333333,
+    "wind_gust_max": 47.5,
+    "wind_speed_avg": 24.920833333333334,
     "wind_speed_max": null
   },
   {
@@ -156,8 +156,8 @@
     "temp_outdoor_max": -6.8,
     "temp_outdoor_min": -12.9,
     "uv_index_max": null,
-    "wind_gust_max": 11.3,
-    "wind_speed_avg": 5.46,
+    "wind_gust_max": 40.7,
+    "wind_speed_avg": 19.67083333333333,
     "wind_speed_max": null
   },
   {
@@ -179,8 +179,8 @@
     "temp_outdoor_max": -4.2,
     "temp_outdoor_min": -11.7,
     "uv_index_max": null,
-    "wind_gust_max": 13.3,
-    "wind_speed_avg": 5.7058333333333335,
+    "wind_gust_max": 47.9,
+    "wind_speed_avg": 20.537500000000005,
     "wind_speed_max": null
   },
   {
@@ -202,8 +202,8 @@
     "temp_outdoor_max": 0.3,
     "temp_outdoor_min": -10.6,
     "uv_index_max": null,
-    "wind_gust_max": 11.6,
-    "wind_speed_avg": 4.854583333333332,
+    "wind_gust_max": 41.8,
+    "wind_speed_avg": 17.483333333333338,
     "wind_speed_max": null
   },
   {
@@ -225,8 +225,8 @@
     "temp_outdoor_max": -0.8,
     "temp_outdoor_min": -7.0,
     "uv_index_max": null,
-    "wind_gust_max": 10.5,
-    "wind_speed_avg": 4.348333333333333,
+    "wind_gust_max": 37.8,
+    "wind_speed_avg": 15.662500000000001,
     "wind_speed_max": null
   }
 ]

--- a/tests/e2e/fixtures/api_v1_observations_daily__end=2023-07-31000000_start=2023-07-15000000_station_id=simulator.json
+++ b/tests/e2e/fixtures/api_v1_observations_daily__end=2023-07-31000000_start=2023-07-15000000_station_id=simulator.json
@@ -18,8 +18,8 @@
     "temp_outdoor_max": 38.0,
     "temp_outdoor_min": 25.5,
     "uv_index_max": null,
-    "wind_gust_max": 7.4,
-    "wind_speed_avg": 3.233333333333334,
+    "wind_gust_max": 26.6,
+    "wind_speed_avg": 11.641666666666666,
     "wind_speed_max": null
   },
   {
@@ -41,8 +41,8 @@
     "temp_outdoor_max": 37.7,
     "temp_outdoor_min": 26.5,
     "uv_index_max": null,
-    "wind_gust_max": 9.9,
-    "wind_speed_avg": 4.107916666666665,
+    "wind_gust_max": 35.6,
+    "wind_speed_avg": 14.783333333333333,
     "wind_speed_max": null
   },
   {
@@ -64,8 +64,8 @@
     "temp_outdoor_max": 37.9,
     "temp_outdoor_min": 27.2,
     "uv_index_max": null,
-    "wind_gust_max": 11.9,
-    "wind_speed_avg": 5.765416666666666,
+    "wind_gust_max": 42.8,
+    "wind_speed_avg": 20.758333333333333,
     "wind_speed_max": null
   },
   {
@@ -87,8 +87,8 @@
     "temp_outdoor_max": 37.8,
     "temp_outdoor_min": 26.6,
     "uv_index_max": null,
-    "wind_gust_max": 11.3,
-    "wind_speed_avg": 5.881666666666667,
+    "wind_gust_max": 40.7,
+    "wind_speed_avg": 21.179166666666667,
     "wind_speed_max": null
   },
   {
@@ -110,8 +110,8 @@
     "temp_outdoor_max": 38.2,
     "temp_outdoor_min": 27.0,
     "uv_index_max": null,
-    "wind_gust_max": 12.5,
-    "wind_speed_avg": 6.2799999999999985,
+    "wind_gust_max": 45.0,
+    "wind_speed_avg": 22.599999999999998,
     "wind_speed_max": null
   },
   {
@@ -133,8 +133,8 @@
     "temp_outdoor_max": 38.8,
     "temp_outdoor_min": 26.7,
     "uv_index_max": null,
-    "wind_gust_max": 12.2,
-    "wind_speed_avg": 6.4174999999999995,
+    "wind_gust_max": 43.9,
+    "wind_speed_avg": 23.1125,
     "wind_speed_max": null
   },
   {
@@ -156,8 +156,8 @@
     "temp_outdoor_max": 38.0,
     "temp_outdoor_min": 23.3,
     "uv_index_max": null,
-    "wind_gust_max": 11.2,
-    "wind_speed_avg": 5.39,
+    "wind_gust_max": 40.3,
+    "wind_speed_avg": 19.412500000000005,
     "wind_speed_max": null
   },
   {
@@ -179,8 +179,8 @@
     "temp_outdoor_max": 34.5,
     "temp_outdoor_min": 21.1,
     "uv_index_max": null,
-    "wind_gust_max": 7.6,
-    "wind_speed_avg": 3.2570833333333327,
+    "wind_gust_max": 27.4,
+    "wind_speed_avg": 11.725,
     "wind_speed_max": null
   },
   {
@@ -202,8 +202,8 @@
     "temp_outdoor_max": 30.3,
     "temp_outdoor_min": 19.7,
     "uv_index_max": null,
-    "wind_gust_max": 7.2,
-    "wind_speed_avg": 1.8854166666666663,
+    "wind_gust_max": 25.9,
+    "wind_speed_avg": 6.787499999999999,
     "wind_speed_max": null
   },
   {
@@ -225,8 +225,8 @@
     "temp_outdoor_max": 29.8,
     "temp_outdoor_min": 23.6,
     "uv_index_max": null,
-    "wind_gust_max": 10.9,
-    "wind_speed_avg": 3.715416666666666,
+    "wind_gust_max": 39.2,
+    "wind_speed_avg": 13.362500000000002,
     "wind_speed_max": null
   },
   {
@@ -248,8 +248,8 @@
     "temp_outdoor_max": 33.2,
     "temp_outdoor_min": 25.9,
     "uv_index_max": null,
-    "wind_gust_max": 11.1,
-    "wind_speed_avg": 3.4179166666666667,
+    "wind_gust_max": 40.0,
+    "wind_speed_avg": 12.304166666666667,
     "wind_speed_max": null
   },
   {
@@ -271,8 +271,8 @@
     "temp_outdoor_max": 38.7,
     "temp_outdoor_min": 28.8,
     "uv_index_max": null,
-    "wind_gust_max": 13.0,
-    "wind_speed_avg": 5.952083333333333,
+    "wind_gust_max": 46.8,
+    "wind_speed_avg": 21.425,
     "wind_speed_max": null
   },
   {
@@ -294,8 +294,8 @@
     "temp_outdoor_max": 38.1,
     "temp_outdoor_min": 26.8,
     "uv_index_max": null,
-    "wind_gust_max": 13.9,
-    "wind_speed_avg": 6.352916666666666,
+    "wind_gust_max": 50.0,
+    "wind_speed_avg": 22.883333333333326,
     "wind_speed_max": null
   },
   {
@@ -317,8 +317,8 @@
     "temp_outdoor_max": 36.8,
     "temp_outdoor_min": 22.5,
     "uv_index_max": null,
-    "wind_gust_max": 8.6,
-    "wind_speed_avg": 3.99875,
+    "wind_gust_max": 31.0,
+    "wind_speed_avg": 14.395833333333334,
     "wind_speed_max": null
   },
   {
@@ -340,8 +340,8 @@
     "temp_outdoor_max": 32.0,
     "temp_outdoor_min": 21.4,
     "uv_index_max": null,
-    "wind_gust_max": 8.5,
-    "wind_speed_avg": 2.5241666666666673,
+    "wind_gust_max": 30.6,
+    "wind_speed_avg": 9.091666666666669,
     "wind_speed_max": null
   },
   {
@@ -363,8 +363,8 @@
     "temp_outdoor_max": 31.6,
     "temp_outdoor_min": 23.2,
     "uv_index_max": null,
-    "wind_gust_max": 10.9,
-    "wind_speed_avg": 3.1570833333333326,
+    "wind_gust_max": 39.2,
+    "wind_speed_avg": 11.375,
     "wind_speed_max": null
   }
 ]

--- a/tests/e2e/fixtures/api_v1_observations_monthly__end=2022-12-31000000_start=2022-01-01000000_station_id=simulator.json
+++ b/tests/e2e/fixtures/api_v1_observations_monthly__end=2022-12-31000000_start=2022-01-01000000_station_id=simulator.json
@@ -18,8 +18,8 @@
     "temp_outdoor_max": 20.7,
     "temp_outdoor_min": -15.4,
     "uv_index_max": null,
-    "wind_gust_max": 22.0,
-    "wind_speed_avg": 4.566760752688173,
+    "wind_gust_max": 79.2,
+    "wind_speed_avg": 16.440322580645162,
     "wind_speed_max": null
   },
   {
@@ -41,8 +41,8 @@
     "temp_outdoor_max": 25.4,
     "temp_outdoor_min": -4.0,
     "uv_index_max": null,
-    "wind_gust_max": 17.1,
-    "wind_speed_avg": 4.781511666666666,
+    "wind_gust_max": 61.6,
+    "wind_speed_avg": 17.213138888888885,
     "wind_speed_max": null
   },
   {
@@ -64,8 +64,8 @@
     "temp_outdoor_max": 32.3,
     "temp_outdoor_min": 2.0,
     "uv_index_max": null,
-    "wind_gust_max": 20.9,
-    "wind_speed_avg": 4.151061827956989,
+    "wind_gust_max": 75.2,
+    "wind_speed_avg": 14.944489247311829,
     "wind_speed_max": null
   },
   {
@@ -87,8 +87,8 @@
     "temp_outdoor_max": 36.5,
     "temp_outdoor_min": 14.8,
     "uv_index_max": null,
-    "wind_gust_max": 14.2,
-    "wind_speed_avg": 3.9611111111111104,
+    "wind_gust_max": 51.1,
+    "wind_speed_avg": 14.261805555555553,
     "wind_speed_max": null
   },
   {
@@ -110,8 +110,8 @@
     "temp_outdoor_max": 38.7,
     "temp_outdoor_min": 19.8,
     "uv_index_max": null,
-    "wind_gust_max": 13.2,
-    "wind_speed_avg": 3.748575268817205,
+    "wind_gust_max": 47.5,
+    "wind_speed_avg": 13.494623655913976,
     "wind_speed_max": null
   },
   {
@@ -133,8 +133,8 @@
     "temp_outdoor_max": 43.5,
     "temp_outdoor_min": 21.9,
     "uv_index_max": null,
-    "wind_gust_max": 13.3,
-    "wind_speed_avg": 4.299220430107527,
+    "wind_gust_max": 47.9,
+    "wind_speed_avg": 15.479301075268815,
     "wind_speed_max": null
   },
   {
@@ -156,8 +156,8 @@
     "temp_outdoor_max": 38.0,
     "temp_outdoor_min": 15.8,
     "uv_index_max": null,
-    "wind_gust_max": 17.6,
-    "wind_speed_avg": 4.500402777777778,
+    "wind_gust_max": 63.4,
+    "wind_speed_avg": 16.203472222222228,
     "wind_speed_max": null
   },
   {
@@ -179,8 +179,8 @@
     "temp_outdoor_max": 35.1,
     "temp_outdoor_min": 7.1,
     "uv_index_max": null,
-    "wind_gust_max": 19.8,
-    "wind_speed_avg": 5.857190860215053,
+    "wind_gust_max": 71.3,
+    "wind_speed_avg": 21.088172043010758,
     "wind_speed_max": null
   },
   {
@@ -202,8 +202,8 @@
     "temp_outdoor_max": 34.5,
     "temp_outdoor_min": 3.7,
     "uv_index_max": null,
-    "wind_gust_max": 22.1,
-    "wind_speed_avg": 6.238972222222222,
+    "wind_gust_max": 79.6,
+    "wind_speed_avg": 22.46138888888889,
     "wind_speed_max": null
   },
   {
@@ -225,8 +225,8 @@
     "temp_outdoor_max": 29.0,
     "temp_outdoor_min": -6.9,
     "uv_index_max": null,
-    "wind_gust_max": 20.3,
-    "wind_speed_avg": 5.4284344319775615,
+    "wind_gust_max": 73.1,
+    "wind_speed_avg": 19.54445418419823,
     "wind_speed_max": null
   },
   {
@@ -248,8 +248,8 @@
     "temp_outdoor_max": 23.2,
     "temp_outdoor_min": -13.4,
     "uv_index_max": null,
-    "wind_gust_max": 21.2,
-    "wind_speed_avg": 5.095119047619048,
+    "wind_gust_max": 76.3,
+    "wind_speed_avg": 18.342857142857145,
     "wind_speed_max": null
   },
   {
@@ -271,8 +271,8 @@
     "temp_outdoor_max": 20.5,
     "temp_outdoor_min": -10.9,
     "uv_index_max": null,
-    "wind_gust_max": 21.0,
-    "wind_speed_avg": 4.696505376344086,
+    "wind_gust_max": 75.6,
+    "wind_speed_avg": 16.90806451612903,
     "wind_speed_max": null
   }
 ]

--- a/tests/e2e/fixtures/api_v1_observations_wind-rose__end=2022-06-30000000_start=2022-06-01000000_station_id=simulator.json
+++ b/tests/e2e/fixtures/api_v1_observations_wind-rose__end=2022-06-30000000_start=2022-06-01000000_station_id=simulator.json
@@ -1,127 +1,222 @@
 [
   {
-    "count": 20,
+    "count": 1,
     "direction": 0.0,
     "speed_range": "0-5"
   },
   {
-    "count": 12,
+    "count": 13,
     "direction": 0.0,
     "speed_range": "5-15"
   },
   {
-    "count": 21,
+    "count": 15,
+    "direction": 0.0,
+    "speed_range": "15-25"
+  },
+  {
+    "count": 3,
+    "direction": 0.0,
+    "speed_range": "25-40"
+  },
+  {
+    "count": 14,
     "direction": 22.5,
-    "speed_range": "0-5"
+    "speed_range": "5-15"
   },
   {
     "count": 15,
     "direction": 22.5,
+    "speed_range": "15-25"
+  },
+  {
+    "count": 7,
+    "direction": 22.5,
+    "speed_range": "25-40"
+  },
+  {
+    "count": 17,
+    "direction": 45.0,
     "speed_range": "5-15"
+  },
+  {
+    "count": 6,
+    "direction": 45.0,
+    "speed_range": "15-25"
+  },
+  {
+    "count": 1,
+    "direction": 45.0,
+    "speed_range": "25-40"
+  },
+  {
+    "count": 2,
+    "direction": 67.5,
+    "speed_range": "0-5"
   },
   {
     "count": 21,
-    "direction": 45.0,
-    "speed_range": "0-5"
+    "direction": 67.5,
+    "speed_range": "5-15"
   },
   {
     "count": 3,
-    "direction": 45.0,
-    "speed_range": "5-15"
-  },
-  {
-    "count": 25,
     "direction": 67.5,
-    "speed_range": "0-5"
+    "speed_range": "15-25"
   },
   {
-    "count": 2,
+    "count": 1,
     "direction": 67.5,
-    "speed_range": "5-15"
+    "speed_range": "25-40"
   },
   {
-    "count": 22,
+    "count": 5,
     "direction": 90.0,
     "speed_range": "0-5"
   },
   {
-    "count": 2,
+    "count": 16,
     "direction": 90.0,
     "speed_range": "5-15"
   },
   {
-    "count": 26,
-    "direction": 112.5,
-    "speed_range": "0-5"
+    "count": 2,
+    "direction": 90.0,
+    "speed_range": "15-25"
+  },
+  {
+    "count": 1,
+    "direction": 90.0,
+    "speed_range": "25-40"
   },
   {
     "count": 1,
     "direction": 112.5,
+    "speed_range": "0-5"
+  },
+  {
+    "count": 22,
+    "direction": 112.5,
     "speed_range": "5-15"
   },
   {
-    "count": 81,
+    "count": 4,
+    "direction": 112.5,
+    "speed_range": "15-25"
+  },
+  {
+    "count": 3,
     "direction": 135.0,
     "speed_range": "0-5"
+  },
+  {
+    "count": 66,
+    "direction": 135.0,
+    "speed_range": "5-15"
+  },
+  {
+    "count": 28,
+    "direction": 135.0,
+    "speed_range": "15-25"
+  },
+  {
+    "count": 2,
+    "direction": 135.0,
+    "speed_range": "25-40"
+  },
+  {
+    "count": 65,
+    "direction": 157.5,
+    "speed_range": "5-15"
+  },
+  {
+    "count": 63,
+    "direction": 157.5,
+    "speed_range": "15-25"
+  },
+  {
+    "count": 19,
+    "direction": 157.5,
+    "speed_range": "25-40"
+  },
+  {
+    "count": 2,
+    "direction": 180.0,
+    "speed_range": "0-5"
+  },
+  {
+    "count": 53,
+    "direction": 180.0,
+    "speed_range": "5-15"
+  },
+  {
+    "count": 83,
+    "direction": 180.0,
+    "speed_range": "15-25"
+  },
+  {
+    "count": 47,
+    "direction": 180.0,
+    "speed_range": "25-40"
+  },
+  {
+    "count": 2,
+    "direction": 202.5,
+    "speed_range": "0-5"
+  },
+  {
+    "count": 22,
+    "direction": 202.5,
+    "speed_range": "5-15"
+  },
+  {
+    "count": 32,
+    "direction": 202.5,
+    "speed_range": "15-25"
   },
   {
     "count": 18,
-    "direction": 135.0,
-    "speed_range": "5-15"
-  },
-  {
-    "count": 86,
-    "direction": 157.5,
-    "speed_range": "0-5"
-  },
-  {
-    "count": 61,
-    "direction": 157.5,
-    "speed_range": "5-15"
-  },
-  {
-    "count": 80,
-    "direction": 180.0,
-    "speed_range": "0-5"
-  },
-  {
-    "count": 105,
-    "direction": 180.0,
-    "speed_range": "5-15"
-  },
-  {
-    "count": 31,
     "direction": 202.5,
-    "speed_range": "0-5"
+    "speed_range": "25-40"
   },
   {
-    "count": 43,
-    "direction": 202.5,
-    "speed_range": "5-15"
-  },
-  {
-    "count": 10,
+    "count": 1,
     "direction": 225.0,
     "speed_range": "0-5"
   },
   {
+    "count": 7,
+    "direction": 225.0,
+    "speed_range": "5-15"
+  },
+  {
+    "count": 2,
+    "direction": 225.0,
+    "speed_range": "15-25"
+  },
+  {
     "count": 1,
     "direction": 270.0,
-    "speed_range": "0-5"
+    "speed_range": "5-15"
   },
   {
     "count": 2,
     "direction": 292.5,
-    "speed_range": "5-15"
+    "speed_range": "15-25"
   },
   {
-    "count": 3,
+    "count": 1,
     "direction": 315.0,
     "speed_range": "0-5"
   },
   {
+    "count": 2,
+    "direction": 315.0,
+    "speed_range": "5-15"
+  },
+  {
     "count": 6,
     "direction": 337.5,
-    "speed_range": "0-5"
+    "speed_range": "5-15"
   }
 ]

--- a/tests/e2e/fixtures/api_v1_records__station_id=simulator.json
+++ b/tests/e2e/fixtures/api_v1_records__station_id=simulator.json
@@ -148,7 +148,7 @@
         {
           "all_time": {
             "date": "2021-12-15",
-            "value": 24.6
+            "value": 88.6
           },
           "label": "Highest Gust",
           "metric": "highest_wind_gust",
@@ -158,7 +158,7 @@
         {
           "all_time": {
             "date": "2021-12-15",
-            "value": 15.03
+            "value": 54.1
           },
           "label": "Highest Wind Speed",
           "metric": "highest_wind_speed",

--- a/tests/e2e/fixtures/api_v1_reports_monthly__month=2_station_id=simulator_year=2021.json
+++ b/tests/e2e/fixtures/api_v1_reports_monthly__month=2_station_id=simulator_year=2021.json
@@ -20,8 +20,8 @@
       "temp_max": 10.7,
       "temp_min": -1.9,
       "wind_dir_prevailing": "NNW",
-      "wind_gust_max": 6.5,
-      "wind_speed_avg": 2.3845833333333335
+      "wind_gust_max": 23.4,
+      "wind_speed_avg": 8.591666666666667
     },
     {
       "cdd": 0.0,
@@ -38,8 +38,8 @@
       "temp_max": 13.7,
       "temp_min": 3.5,
       "wind_dir_prevailing": "SSE",
-      "wind_gust_max": 11.4,
-      "wind_speed_avg": 4.606249999999999
+      "wind_gust_max": 41.0,
+      "wind_speed_avg": 16.595833333333335
     },
     {
       "cdd": 0.0,
@@ -56,8 +56,8 @@
       "temp_max": 16.2,
       "temp_min": 4.4,
       "wind_dir_prevailing": "SSE",
-      "wind_gust_max": 15.5,
-      "wind_speed_avg": 6.515
+      "wind_gust_max": 55.8,
+      "wind_speed_avg": 23.458333333333332
     },
     {
       "cdd": 0.0,
@@ -74,8 +74,8 @@
       "temp_max": 14.9,
       "temp_min": 0.8,
       "wind_dir_prevailing": "NNW",
-      "wind_gust_max": 19.3,
-      "wind_speed_avg": 7.442916666666668
+      "wind_gust_max": 69.5,
+      "wind_speed_avg": 26.783333333333335
     },
     {
       "cdd": 0.0,
@@ -92,8 +92,8 @@
       "temp_max": 11.1,
       "temp_min": -0.2,
       "wind_dir_prevailing": "SSE",
-      "wind_gust_max": 6.7,
-      "wind_speed_avg": 2.9204166666666667
+      "wind_gust_max": 24.1,
+      "wind_speed_avg": 10.516666666666667
     },
     {
       "cdd": 0.0,
@@ -110,8 +110,8 @@
       "temp_max": 7.1,
       "temp_min": -3.2,
       "wind_dir_prevailing": "SE",
-      "wind_gust_max": 13.2,
-      "wind_speed_avg": 3.9445833333333336
+      "wind_gust_max": 47.5,
+      "wind_speed_avg": 14.191666666666665
     },
     {
       "cdd": 0.0,
@@ -128,8 +128,8 @@
       "temp_max": 7.3,
       "temp_min": -4.0,
       "wind_dir_prevailing": "ESE",
-      "wind_gust_max": 8.8,
-      "wind_speed_avg": 3.530833333333334
+      "wind_gust_max": 31.7,
+      "wind_speed_avg": 12.716666666666663
     },
     {
       "cdd": 0.0,
@@ -146,8 +146,8 @@
       "temp_max": 1.5,
       "temp_min": -5.3,
       "wind_dir_prevailing": "N",
-      "wind_gust_max": 10.1,
-      "wind_speed_avg": 4.77
+      "wind_gust_max": 36.4,
+      "wind_speed_avg": 17.166666666666668
     },
     {
       "cdd": 0.0,
@@ -164,8 +164,8 @@
       "temp_max": 0.9,
       "temp_min": -9.8,
       "wind_dir_prevailing": "NNE",
-      "wind_gust_max": 10.4,
-      "wind_speed_avg": 3.923333333333332
+      "wind_gust_max": 37.4,
+      "wind_speed_avg": 14.133333333333335
     },
     {
       "cdd": 0.0,
@@ -182,8 +182,8 @@
       "temp_max": -0.8,
       "temp_min": -7.0,
       "wind_dir_prevailing": "N",
-      "wind_gust_max": 10.5,
-      "wind_speed_avg": 4.348333333333333
+      "wind_gust_max": 37.8,
+      "wind_speed_avg": 15.662500000000001
     },
     {
       "cdd": 0.0,
@@ -200,8 +200,8 @@
       "temp_max": 0.3,
       "temp_min": -10.6,
       "wind_dir_prevailing": "N",
-      "wind_gust_max": 11.6,
-      "wind_speed_avg": 4.854583333333332
+      "wind_gust_max": 41.8,
+      "wind_speed_avg": 17.483333333333338
     },
     {
       "cdd": 0.0,
@@ -218,8 +218,8 @@
       "temp_max": -4.2,
       "temp_min": -11.7,
       "wind_dir_prevailing": "N",
-      "wind_gust_max": 13.3,
-      "wind_speed_avg": 5.7058333333333335
+      "wind_gust_max": 47.9,
+      "wind_speed_avg": 20.537500000000005
     },
     {
       "cdd": 0.0,
@@ -236,8 +236,8 @@
       "temp_max": -6.8,
       "temp_min": -12.9,
       "wind_dir_prevailing": "NNE",
-      "wind_gust_max": 11.3,
-      "wind_speed_avg": 5.46
+      "wind_gust_max": 40.7,
+      "wind_speed_avg": 19.67083333333333
     },
     {
       "cdd": 0.0,
@@ -254,8 +254,8 @@
       "temp_max": -10.8,
       "temp_min": -16.8,
       "wind_dir_prevailing": "NNE",
-      "wind_gust_max": 13.2,
-      "wind_speed_avg": 6.920833333333333
+      "wind_gust_max": 47.5,
+      "wind_speed_avg": 24.920833333333334
     },
     {
       "cdd": 0.0,
@@ -272,8 +272,8 @@
       "temp_max": -17.1,
       "temp_min": -23.0,
       "wind_dir_prevailing": "NNW",
-      "wind_gust_max": 13.1,
-      "wind_speed_avg": 5.617916666666666
+      "wind_gust_max": 47.2,
+      "wind_speed_avg": 20.229166666666668
     },
     {
       "cdd": 0.0,
@@ -290,8 +290,8 @@
       "temp_max": -10.6,
       "temp_min": -25.8,
       "wind_dir_prevailing": "SE",
-      "wind_gust_max": 6.4,
-      "wind_speed_avg": 2.5429166666666667
+      "wind_gust_max": 23.0,
+      "wind_speed_avg": 9.162500000000003
     },
     {
       "cdd": 0.0,
@@ -308,8 +308,8 @@
       "temp_max": -6.8,
       "temp_min": -12.0,
       "wind_dir_prevailing": "NNW",
-      "wind_gust_max": 7.0,
-      "wind_speed_avg": 2.8370833333333336
+      "wind_gust_max": 25.2,
+      "wind_speed_avg": 10.216666666666669
     },
     {
       "cdd": 0.0,
@@ -326,8 +326,8 @@
       "temp_max": -7.4,
       "temp_min": -16.1,
       "wind_dir_prevailing": "NNW",
-      "wind_gust_max": 8.5,
-      "wind_speed_avg": 3.689166666666667
+      "wind_gust_max": 30.6,
+      "wind_speed_avg": 13.283333333333333
     },
     {
       "cdd": 0.0,
@@ -344,8 +344,8 @@
       "temp_max": 0.2,
       "temp_min": -18.2,
       "wind_dir_prevailing": "SSW",
-      "wind_gust_max": 5.3,
-      "wind_speed_avg": 2.7966666666666673
+      "wind_gust_max": 19.1,
+      "wind_speed_avg": 10.070833333333335
     },
     {
       "cdd": 0.0,
@@ -362,8 +362,8 @@
       "temp_max": 5.1,
       "temp_min": -7.5,
       "wind_dir_prevailing": "SSE",
-      "wind_gust_max": 14.5,
-      "wind_speed_avg": 5.101250000000001
+      "wind_gust_max": 52.2,
+      "wind_speed_avg": 18.35416666666667
     },
     {
       "cdd": 0.0,
@@ -380,8 +380,8 @@
       "temp_max": 10.5,
       "temp_min": -0.3,
       "wind_dir_prevailing": "NW",
-      "wind_gust_max": 16.0,
-      "wind_speed_avg": 6.079166666666666
+      "wind_gust_max": 57.6,
+      "wind_speed_avg": 21.88333333333333
     },
     {
       "cdd": 0.0,
@@ -398,8 +398,8 @@
       "temp_max": 15.4,
       "temp_min": -2.1,
       "wind_dir_prevailing": "SW",
-      "wind_gust_max": 13.8,
-      "wind_speed_avg": 4.335416666666666
+      "wind_gust_max": 49.7,
+      "wind_speed_avg": 15.608333333333333
     },
     {
       "cdd": 0.0,
@@ -416,8 +416,8 @@
       "temp_max": 18.5,
       "temp_min": 0.6,
       "wind_dir_prevailing": "S",
-      "wind_gust_max": 12.7,
-      "wind_speed_avg": 4.5929166666666665
+      "wind_gust_max": 45.7,
+      "wind_speed_avg": 16.524999999999995
     },
     {
       "cdd": 0.0,
@@ -434,8 +434,8 @@
       "temp_max": 14.4,
       "temp_min": 4.3,
       "wind_dir_prevailing": "N",
-      "wind_gust_max": 15.0,
-      "wind_speed_avg": 6.552499999999999
+      "wind_gust_max": 54.0,
+      "wind_speed_avg": 23.583333333333332
     },
     {
       "cdd": 0.0,
@@ -452,8 +452,8 @@
       "temp_max": 11.1,
       "temp_min": 0.1,
       "wind_dir_prevailing": "NE",
-      "wind_gust_max": 10.1,
-      "wind_speed_avg": 4.630000000000001
+      "wind_gust_max": 36.4,
+      "wind_speed_avg": 16.679166666666667
     },
     {
       "cdd": 0.0,
@@ -470,8 +470,8 @@
       "temp_max": 12.9,
       "temp_min": 0.8,
       "wind_dir_prevailing": "SSW",
-      "wind_gust_max": 9.5,
-      "wind_speed_avg": 3.106666666666667
+      "wind_gust_max": 34.2,
+      "wind_speed_avg": 11.179166666666667
     },
     {
       "cdd": 0.0,
@@ -488,8 +488,8 @@
       "temp_max": 16.0,
       "temp_min": 4.8,
       "wind_dir_prevailing": "SSE",
-      "wind_gust_max": 13.8,
-      "wind_speed_avg": 5.526666666666667
+      "wind_gust_max": 49.7,
+      "wind_speed_avg": 19.899999999999995
     },
     {
       "cdd": 0.0,
@@ -506,8 +506,8 @@
       "temp_max": 15.9,
       "temp_min": 5.4,
       "wind_dir_prevailing": "N",
-      "wind_gust_max": 14.5,
-      "wind_speed_avg": 6.460416666666666
+      "wind_gust_max": 52.2,
+      "wind_speed_avg": 23.26666666666667
     }
   ],
   "station": {
@@ -527,7 +527,7 @@
     "temp_min": -25.8,
     "temp_min_date": "2021-02-16",
     "wind_dir_prevailing": "N",
-    "wind_gust_max": 19.3,
+    "wind_gust_max": 69.5,
     "wind_gust_max_date": "2021-02-04"
   }
 }

--- a/tests/e2e/fixtures/api_v1_reports_yearly__station_id=simulator_year=2022.json
+++ b/tests/e2e/fixtures/api_v1_reports_yearly__station_id=simulator_year=2022.json
@@ -20,8 +20,8 @@
       "temp_max": 20.5,
       "temp_min": -10.9,
       "wind_dir_prevailing": "N",
-      "wind_gust_max": 21.0,
-      "wind_speed_avg": 4.7
+      "wind_gust_max": 75.6,
+      "wind_speed_avg": 16.9
     },
     {
       "cdd": 0.0,
@@ -38,8 +38,8 @@
       "temp_max": 23.2,
       "temp_min": -13.4,
       "wind_dir_prevailing": "S",
-      "wind_gust_max": 21.2,
-      "wind_speed_avg": 5.1
+      "wind_gust_max": 76.3,
+      "wind_speed_avg": 18.3
     },
     {
       "cdd": 0.0,
@@ -56,8 +56,8 @@
       "temp_max": 29.0,
       "temp_min": -6.9,
       "wind_dir_prevailing": "S",
-      "wind_gust_max": 20.3,
-      "wind_speed_avg": 5.4
+      "wind_gust_max": 73.1,
+      "wind_speed_avg": 19.5
     },
     {
       "cdd": 0.0,
@@ -74,8 +74,8 @@
       "temp_max": 34.5,
       "temp_min": 3.7,
       "wind_dir_prevailing": "S",
-      "wind_gust_max": 22.1,
-      "wind_speed_avg": 6.2
+      "wind_gust_max": 79.6,
+      "wind_speed_avg": 22.5
     },
     {
       "cdd": 3.9,
@@ -92,8 +92,8 @@
       "temp_max": 35.1,
       "temp_min": 7.1,
       "wind_dir_prevailing": "S",
-      "wind_gust_max": 19.8,
-      "wind_speed_avg": 5.9
+      "wind_gust_max": 71.3,
+      "wind_speed_avg": 21.1
     },
     {
       "cdd": 8.7,
@@ -110,8 +110,8 @@
       "temp_max": 38.0,
       "temp_min": 15.8,
       "wind_dir_prevailing": "S",
-      "wind_gust_max": 17.6,
-      "wind_speed_avg": 4.5
+      "wind_gust_max": 63.4,
+      "wind_speed_avg": 16.2
     },
     {
       "cdd": 13.3,
@@ -128,8 +128,8 @@
       "temp_max": 43.5,
       "temp_min": 21.9,
       "wind_dir_prevailing": "S",
-      "wind_gust_max": 13.3,
-      "wind_speed_avg": 4.3
+      "wind_gust_max": 47.9,
+      "wind_speed_avg": 15.5
     },
     {
       "cdd": 10.4,
@@ -146,8 +146,8 @@
       "temp_max": 38.7,
       "temp_min": 19.8,
       "wind_dir_prevailing": "S",
-      "wind_gust_max": 13.2,
-      "wind_speed_avg": 3.7
+      "wind_gust_max": 47.5,
+      "wind_speed_avg": 13.5
     },
     {
       "cdd": 7.2,
@@ -164,8 +164,8 @@
       "temp_max": 36.5,
       "temp_min": 14.8,
       "wind_dir_prevailing": "S",
-      "wind_gust_max": 14.2,
-      "wind_speed_avg": 4.0
+      "wind_gust_max": 51.1,
+      "wind_speed_avg": 14.3
     },
     {
       "cdd": 0.0,
@@ -182,8 +182,8 @@
       "temp_max": 32.3,
       "temp_min": 2.0,
       "wind_dir_prevailing": "S",
-      "wind_gust_max": 20.9,
-      "wind_speed_avg": 4.2
+      "wind_gust_max": 75.2,
+      "wind_speed_avg": 14.9
     },
     {
       "cdd": 0.0,
@@ -200,8 +200,8 @@
       "temp_max": 25.4,
       "temp_min": -4.0,
       "wind_dir_prevailing": "S",
-      "wind_gust_max": 17.1,
-      "wind_speed_avg": 4.8
+      "wind_gust_max": 61.6,
+      "wind_speed_avg": 17.2
     },
     {
       "cdd": 0.0,
@@ -218,8 +218,8 @@
       "temp_max": 20.7,
       "temp_min": -15.4,
       "wind_dir_prevailing": "S",
-      "wind_gust_max": 22.0,
-      "wind_speed_avg": 4.6
+      "wind_gust_max": 79.2,
+      "wind_speed_avg": 16.4
     }
   ],
   "station": {
@@ -239,7 +239,7 @@
     "temp_min": -15.4,
     "temp_min_date": "2022-12-23",
     "wind_dir_prevailing": "S",
-    "wind_gust_max": 22.1,
+    "wind_gust_max": 79.6,
     "wind_gust_max_date": "2022-04-23"
   }
 }


### PR DESCRIPTION
## Summary
- v2026.4.28.2 flipped the simulator's `wind_speed_unit` from `ms` to `kmh` to match production, but the E2E golden fixtures were captured pre-flip — 7 tests fail in CI with `actual / expected ≈ 3.6` (the km/h ÷ m/s ratio) on every wind value.
- Regenerated all 8 fixtures against a freshly-seeded test stack. Diffs are wind-only: `wind_speed_avg`, `wind_gust_max`, plus `wind-rose` speed-range buckets reshuffling as values cross thresholds. The `calendar` fixture (`temp_outdoor_max`) is unchanged.

## Test plan
- [x] Full E2E suite passes locally (`docker compose -f docker/docker-compose.yml -f docker/docker-compose.test.yml up --abort-on-container-exit --exit-code-from test-runner`)
- [ ] CI E2E job green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)