### PR TITLE
chore(security): add release cooldowns to Dependabot and pnpm

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,13 @@ updates:
           - minor
           - patch
     open-pull-requests-limit: 10
+    cooldown:
+      default-days: 7
+      semver-major-days: 14
+      semver-minor-days: 7
+      semver-patch-days: 3
+      include:
+        - "*"
 
   - package-ecosystem: pip
     directory: /backend
@@ -24,9 +31,23 @@ updates:
           - minor
           - patch
     open-pull-requests-limit: 10
+    cooldown:
+      default-days: 7
+      semver-major-days: 14
+      semver-minor-days: 7
+      semver-patch-days: 3
+      include:
+        - "*"
 
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: weekly
       day: monday
+    cooldown:
+      default-days: 7
+      semver-major-days: 14
+      semver-minor-days: 7
+      semver-patch-days: 3
+      include:
+        - "*"

--- a/frontend/.npmrc
+++ b/frontend/.npmrc
@@ -1,0 +1,1 @@
+minimum-release-age=10080


### PR DESCRIPTION
## Summary
- Add tiered Dependabot `cooldown:` (14d major / 7d minor / 3d patch, default 7d) to the npm, pip, and github-actions ecosystems.
- Add `frontend/.npmrc` with `minimum-release-age=10080` (7 days) so pnpm refuses to install freshly published versions even on manual `pnpm install`.

Motivation: defense in depth against supply-chain attacks like the recent TanStack incident — gives auditors/scanners a window to flag malicious releases before they enter the dep tree.

Note: uv has no rolling cooldown equivalent; backend Python protection comes from the Dependabot `pip` cooldown.

## Test plan
- [ ] Dependabot run on Monday opens no PRs for releases newer than the tier window.
- [ ] `pnpm install` in `frontend/` resolves the same lockfile (no version drift).

https://claude.ai/code/session_01VvKxULgv4qL2PtUGJcnbTk

---
_Generated by [Claude Code](https://claude.ai/code/session_01VvKxULgv4qL2PtUGJcnbTk)_