### PR TITLE
test(main): fix route-registration tests for FastAPI >=0.138

### DIFF
--- a/backend/tests/test_main.py
+++ b/backend/tests/test_main.py
@@ -5,7 +5,10 @@ class TestAppRoutes:
     def test_api_routes_registered(self):
         from app.main import app
 
-        paths = [r.path for r in app.routes]
+        # FastAPI >=0.138 stopped flattening included routers into app.routes
+        # (they become opaque _IncludedRouter wrappers without a .path), so we
+        # assert against the OpenAPI schema, which enumerates every HTTP path.
+        paths = app.openapi()["paths"]
         assert "/api/v1/observations/latest" in paths
         assert "/api/v1/observations" in paths
         assert "/api/v1/stations" in paths
@@ -20,8 +23,9 @@ class TestAppRoutes:
     def test_websocket_route_registered(self):
         from app.main import app
 
-        paths = [r.path for r in app.routes]
-        assert "/ws/live" in paths
+        # WebSocket routes are absent from the OpenAPI schema; url_path_for
+        # resolves the route by name and raises if it is not registered.
+        assert app.url_path_for("websocket_live") == "/ws/live"
 
     def test_cors_middleware_present(self):
         from app.main import app


### PR DESCRIPTION
## Problem

The backend Dependabot PRs (#33 starlette, #36 pydantic-settings) fail CI on two tests:

```
tests/test_main.py::TestAppRoutes::test_api_routes_registered     - AttributeError: '_IncludedRouter' object has no attribute 'path'
tests/test_main.py::TestAppRoutes::test_websocket_route_registered - AttributeError: '_IncludedRouter' object has no attribute 'path'
```

## Root cause

This is **not** a problem with either dependency. CI installs the backend with `uv pip install -e ".[dev]"`, which **ignores `uv.lock` and resolves fresh from PyPI** — so it picks up **FastAPI 0.138.x**. In 0.138, `include_router()` no longer flattens sub-routes into `app.routes`; instead it inserts opaque `_IncludedRouter` wrapper objects that have no `.path`. The tests did `[r.path for r in app.routes]`, which now throws.

Because the backend Dependabot PRs trigger backend CI (path-scoped), they surface the failure; `main` would fail the same way if its backend CI re-ran.

## Fix

Assert against **public, version-stable APIs** instead of FastAPI's internal route objects:

- HTTP routes → `app.openapi()["paths"]`
- WebSocket route → `app.url_path_for("websocket_live")` (WebSockets aren't in the OpenAPI schema)

Deliberately avoids the private `_IncludedRouter` / `effective_route_contexts` internals — depending on those is what made the test brittle in the first place.

## Verification

- ✅ Full backend suite (251 tests) passes on **FastAPI 0.138.1** (the version CI resolves)
- ✅ `test_main.py` passes on the **locked FastAPI 0.135.3 / Starlette 1.0.1**
- ✅ `ruff` clean

Once merged, #33 and #36 just need a rebase to go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)