### PR TITLE
feat(deps): migrate to SunCalc 2.0 (supersedes #47)

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,7 +22,7 @@
     "react": "19.2.7",
     "react-dom": "19.2.7",
     "react-leaflet": "^5.0.0",
-    "suncalc": "^1.9.0",
+    "suncalc": "^2.0.1",
     "tailwind-merge": "^3.6.0",
     "uplot": "^1.6.32"
   },
@@ -35,7 +35,6 @@
     "@types/node": "^26",
     "@types/react": "^19",
     "@types/react-dom": "^19",
-    "@types/suncalc": "^1.9.2",
     "@vitest/coverage-v8": "^4.1.9",
     "eslint": "^9",
     "eslint-config-next": "16.2.6",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -46,8 +46,8 @@ importers:
         specifier: ^5.0.0
         version: 5.0.0(leaflet@1.9.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       suncalc:
-        specifier: ^1.9.0
-        version: 1.9.0
+        specifier: ^2.0.1
+        version: 2.0.2
       tailwind-merge:
         specifier: ^3.6.0
         version: 3.6.0
@@ -79,9 +79,6 @@ importers:
       '@types/react-dom':
         specifier: ^19
         version: 19.2.3(@types/react@19.2.17)
-      '@types/suncalc':
-        specifier: ^1.9.2
-        version: 1.9.2
       '@vitest/coverage-v8':
         specifier: ^4.1.9
         version: 4.1.9(vitest@4.1.6)
@@ -1142,9 +1139,6 @@ packages:
 
   '@types/react@19.2.17':
     resolution: {integrity: sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==}
-
-  '@types/suncalc@1.9.2':
-    resolution: {integrity: sha512-ATAGBHHfA1TlE2tjfidLyTcysjoT2JHHEAmWRULh73SU9UTn++j5fqHEW16X6Y/2Li87jEQXzgu4R/OOdlDqzw==}
 
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
@@ -2947,8 +2941,8 @@ packages:
       babel-plugin-macros:
         optional: true
 
-  suncalc@1.9.0:
-    resolution: {integrity: sha512-vMJ8Byp1uIPoj+wb9c1AdK4jpkSKVAywgHX0lqY7zt6+EWRRC3Z+0Ucfjy/0yxTVO1hwwchZe4uoFNqrIC24+A==}
+  suncalc@2.0.2:
+    resolution: {integrity: sha512-cedP91TuhxggoERke/jLkUVr/VMUifEMz1OkxfBZezvOFQdk8LSe9CFv7/Ov0Frn2tc2YUs+44oSrXeNEyTyGQ==}
 
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
@@ -4225,8 +4219,6 @@ snapshots:
   '@types/react@19.2.17':
     dependencies:
       csstype: 3.2.3
-
-  '@types/suncalc@1.9.2': {}
 
   '@types/unist@3.0.3': {}
 
@@ -6290,7 +6282,7 @@ snapshots:
     optionalDependencies:
       '@babel/core': 7.29.6
 
-  suncalc@1.9.0: {}
+  suncalc@2.0.2: {}
 
   supports-color@7.2.0:
     dependencies:

--- a/frontend/src/app/console/page.tsx
+++ b/frontend/src/app/console/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useMemo } from "react";
 import localFont from "next/font/local";
-import SunCalc from "suncalc";
+import * as SunCalc from "suncalc";
 import { keepPreviousData } from "@tanstack/react-query";
 import type { AggregatedObservation, Observation, Station } from "@/generated/models";
 import { useGetLatestObservation } from "@/generated/observations/observations";
@@ -125,6 +125,12 @@ export default function ConsolePage() {
     const yesterdayTimes = SunCalc.getTimes(yesterday, lat, lon);
 
     const { sunrise, sunset } = times;
+
+    // SunCalc 2 returns null when the event doesn't occur (polar day/night).
+    if (!sunrise || !sunset || !yesterdayTimes.sunrise || !yesterdayTimes.sunset) {
+      return null;
+    }
+
     const dayLengthMs = sunset.getTime() - sunrise.getTime();
     const dayLengthMinutes = Math.floor(dayLengthMs / 60000);
     const dayH = Math.floor(dayLengthMinutes / 60);

--- a/frontend/src/components/dashboard/MoonCard.test.tsx
+++ b/frontend/src/components/dashboard/MoonCard.test.tsx
@@ -3,18 +3,17 @@ import { screen } from "@testing-library/react";
 import { renderWithProviders } from "@/test/wrappers";
 import MoonCard from "./MoonCard";
 
-// Mock SunCalc
+// Mock SunCalc — v2 is ESM with named exports (no default).
 vi.mock("suncalc", () => ({
-  default: {
-    getMoonIllumination: () => ({
-      phase: 0.5, // Full Moon
-      fraction: 0.98,
-    }),
-    getMoonTimes: () => ({
-      rise: new Date("2026-04-05T19:00:00"),
-      set: new Date("2026-04-06T06:00:00"),
-    }),
-  },
+  getMoonIllumination: () => ({
+    phase: 0.5, // Full Moon
+    fraction: 0.98,
+    waxing: false,
+  }),
+  getMoonTimes: () => ({
+    rise: new Date("2026-04-05T19:00:00"),
+    set: new Date("2026-04-06T06:00:00"),
+  }),
 }));
 
 // Mock stations API

--- a/frontend/src/components/dashboard/MoonCard.tsx
+++ b/frontend/src/components/dashboard/MoonCard.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useMemo } from "react";
-import SunCalc from "suncalc";
+import * as SunCalc from "suncalc";
 import { RiMoonLine } from "@remixicon/react";
 import { useListStations } from "@/generated/stations/stations";
 import type { Station } from "@/generated/models";
@@ -113,8 +113,15 @@ export default function MoonCard() {
     let set: Date | undefined;
 
     if (hasLocation) {
+      // SunCalc 2 scans the UTC calendar day of the instant it's given; v1 took
+      // an `inUTC` flag and scanned the local day. Passing local midnight keeps
+      // the window pinned to today's local date instead of rolling over to the
+      // next UTC day during the evening.
+      const localMidnight = new Date(now);
+      localMidnight.setHours(0, 0, 0, 0);
+
       const times = SunCalc.getMoonTimes(
-        now,
+        localMidnight,
         station!.latitude!,
         station!.longitude!,
       );

--- a/frontend/src/components/dashboard/SunCard.test.tsx
+++ b/frontend/src/components/dashboard/SunCard.test.tsx
@@ -4,18 +4,18 @@ import { renderWithProviders } from "@/test/wrappers";
 import { makeObservation } from "@/test/fixtures";
 import SunCard from "./SunCard";
 
+// SunCalc 2 is ESM with named exports (no default), and reports angles in
+// degrees rather than radians.
 vi.mock("suncalc", () => ({
-  default: {
-    getTimes: () => ({
-      sunrise: new Date("2026-04-05T06:30:00"),
-      sunset: new Date("2026-04-05T18:15:00"),
-      solarNoon: new Date("2026-04-05T12:22:00"),
-      goldenHour: new Date("2026-04-05T17:30:00"),
-    }),
-    getPosition: () => ({
-      altitude: (45 * Math.PI) / 180,
-    }),
-  },
+  getTimes: () => ({
+    sunrise: new Date("2026-04-05T06:30:00"),
+    sunset: new Date("2026-04-05T18:15:00"),
+    solarNoon: new Date("2026-04-05T12:22:00"),
+    goldenHour: new Date("2026-04-05T17:30:00"),
+  }),
+  getPosition: () => ({
+    altitude: 45,
+  }),
 }));
 
 vi.mock("@/generated/stations/stations", () => ({

--- a/frontend/src/components/dashboard/SunCard.tsx
+++ b/frontend/src/components/dashboard/SunCard.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useMemo } from "react";
-import SunCalc from "suncalc";
+import * as SunCalc from "suncalc";
 import { RiSunLine } from "@remixicon/react";
 import { useListStations } from "@/generated/stations/stations";
 import type { Station, Observation, BrokenRecord } from "@/generated/models";
@@ -13,7 +13,8 @@ import TrendIndicator from "./TrendIndicator";
 import InfoTip from "@/components/ui/InfoTip";
 import RecordBadge from "@/components/ui/RecordBadge";
 
-function fmtTime(d: Date): string {
+function fmtTime(d: Date | null | undefined): string {
+  if (!d) return "\u2014";
   return d.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", hour12: false });
 }
 
@@ -55,6 +56,13 @@ export default function SunCard({ data, solarTrend, uvTrend, brokenRecords }: { 
 
     const { sunrise, sunset, solarNoon, goldenHour } = times;
 
+    // SunCalc 2 returns null for events that don't occur (polar day/night).
+    // Every value below is derived from a sunrise/sunset pair, so without one
+    // there is nothing to draw — fall back to the card's "no data" branch.
+    if (!sunrise || !sunset || !yesterdayTimes.sunrise || !yesterdayTimes.sunset) {
+      return null;
+    }
+
     const dayLengthMs = sunset.getTime() - sunrise.getTime();
     const dayLengthMinutes = Math.floor(dayLengthMs / 60000);
     const dayH = Math.floor(dayLengthMinutes / 60);
@@ -71,7 +79,7 @@ export default function SunCard({ data, solarTrend, uvTrend, brokenRecords }: { 
     const deltaStr = `${sign}${deltaMin}m ${deltaSRemaining}s`;
     const gaining = deltaSec >= 0;
 
-    const currentAltDeg = (position.altitude * 180) / Math.PI;
+    const currentAltDeg = position.altitude;
     const altitudeDeg = Math.round(currentAltDeg);
 
     const totalMs = sunset.getTime() - sunrise.getTime();
@@ -93,8 +101,7 @@ export default function SunCard({ data, solarTrend, uvTrend, brokenRecords }: { 
     for (let i = 0; i < NUM_SAMPLES; i++) {
       const t = i / (NUM_SAMPLES - 1);
       const sampleTime = new Date(sunrise.getTime() + t * totalMs);
-      const sampleAlt =
-        (SunCalc.getPosition(sampleTime, lat, lon).altitude * 180) / Math.PI;
+      const sampleAlt = SunCalc.getPosition(sampleTime, lat, lon).altitude;
       const x = ARC_X0 + t * ARC_WIDTH;
       const y = altToY(sampleAlt);
       coords.push(`${x.toFixed(1)},${y.toFixed(1)}`);


### PR DESCRIPTION
Supersedes #47, which cannot be merged as a plain version bump — suncalc 2.0 is a precision-focused rewrite with breaking changes to units and API shape.

Closes #47.

## What changed

| Change | Caught by | Sites |
| --- | --- | --- |
| ESM named exports, no default | `tsc` (TS1192) | `SunCard.tsx`, `MoonCard.tsx`, `console/page.tsx` |
| **Angles now degrees, not radians** | **nothing** | `SunCard.tsx` — current altitude + 61-sample arc loop |
| `getTimes` returns `Date \| null` per event | `tsc` | `SunCard.tsx`, `console/page.tsx` |
| **`getMoonTimes` dropped `inUTC`, scans UTC day** | **nothing** | `MoonCard.tsx` |
| v2 ships own typings | — | dropped `@types/suncalc` |

The two middle-column "nothing" rows are the reason this needed a branch rather than a rubber stamp.

**Degrees vs radians.** Left in place, the old `* 180 / Math.PI` scales a real 45° altitude to ~2578. `altToY`'s `deg / 90` then clamps every arc sample to the top of the card, silently flattening the astronomical sun curve into a straight line. No type error, no test failure.

**Moon times.** v2 scans the UTC calendar day of the instant it is given. Passing `now` makes the card flip to *tomorrow's* moonrise/set at 20:00 EDT (00:00 UTC) every evening. Passing local midnight keeps the window on today's local date.

Azimuth also became north-based, but nothing in the app reads azimuth. `getMoonIllumination` gained a `waxing` flag; `getPhaseName` already derives waxing/waning from the phase value, so it is unchanged.

## Verification

`tsc` ✓ · `eslint` ✓ · **601 tests** ✓ · `next build` ✓

The suite mocks SunCalc entirely, so it is **no evidence** for the unit change. Verified independently instead:

- Arc math against the real library — peak altitude matches `90 − lat + declination` at 39.125°N: **57.5°** today, **74.3°** at summer solstice, **27.4°** at winter. Arc anchors at the horizon both ends; seasonal height variation preserved.
- Every rendered value cross-checked against SunCalc output on live Pi data — sunrise 06:43, sunset 19:35, solar noon 13:09, golden hour 18:59, day length 12h 51m, delta −2m 28s, **altitude 32°**, moonrise 00:03, moonset 16:06, illumination 36%. All exact.
- Sun arc and Lunar card rendered and inspected in-browser; Console page sun block verified too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0151MxVqVhjffC7xAThxpyV2