### PR TITLE
chore(release): bump version to 2026.9.5.1

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "waffleweather-backend"
-version = "2026.8.22.1"
+version = "2026.9.5.1"
 description = "WaffleWeather - Modern weather station backend"
 requires-python = ">=3.12"
 dependencies = [

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1402,7 +1402,7 @@ wheels = [
 
 [[package]]
 name = "waffleweather-backend"
-version = "2026.8.22.1"
+version = "2026.9.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiomqtt" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "2026.8.22.1",
+  "version": "2026.9.5.1",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
CalVer bump for the release covering #55 (SunCalc 2.0 migration) and #56 (minor-and-patch group + clearing all 19 Dependabot alerts).

`2026.8.22.1` → `2026.9.5.1`

Three files move together:
- `frontend/package.json`
- `backend/pyproject.toml`
- `backend/uv.lock` — records the editable package's own version. Without it, `uv sync --frozen` fails in backend CI and on the Pi deploy. Regenerated with `uv lock`; the diff is that one line, no dependency churn.

Verified `uv sync --frozen --extra dev` resolves to 2026.9.5.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0151MxVqVhjffC7xAThxpyV2